### PR TITLE
Add Ender3 board directory map

### DIFF
--- a/Directory_Map_Ender3_v1.1.4.md
+++ b/Directory_Map_Ender3_v1.1.4.md
@@ -1,0 +1,38 @@
+# Directory Visualizer for Creality Ender 3 (Board v1.1.4)
+
+The following map shows the main components of this repository and how they
+relate when flashing and configuring Klipper for an Ender 3 running the stock
+Creality v1.1.4 controller board.
+
+```
+.
+├── client.cfg                # Example configuration for Fluidd/Mainsail
+├── fluidd/                   # Web UI assets
+├── fluidd.cfg                # Base Klipper macro set
+├── fluidd-moonraker-update.conf  # Update service
+├── kiauh-backups/            # Backup configs from KIAUH helper
+├── kiuah/                    # KIAUH helper scripts
+├── klipper/                  # Klipper firmware source
+│   ├── config/               # Example printer configs
+│   ├── docs/                 # Documentation
+│   ├── klippy/               # Firmware Python code
+│   ├── ...
+├── moonraker/                # Moonraker API server
+│   ├── docs/
+│   ├── moonraker/
+│   └── ...
+└── README.md
+```
+
+## Ender 3 Board Configuration
+
+For the Creality Ender 3 with the 8‑bit v1.1.4 control board, reference the
+configuration file located at:
+
+```
+klipper/config/printer-creality-ender3-2018.cfg
+```
+
+Compile Klipper for the `atmega1284p` MCU and use this configuration as a
+starting point for your printer.
+


### PR DESCRIPTION
## Summary
- add `Directory_Map_Ender3_v1.1.4.md` with overview of repository layout

## Testing
- `apt-get update`
- `apt-get install -y tree`


------
https://chatgpt.com/codex/tasks/task_e_6844859da39c832fac27473c32fa59eb