### PR TITLE
Add desktop UI prototype

### DIFF
--- a/desktop_app/README.md
+++ b/desktop_app/README.md
@@ -1,0 +1,27 @@
+# Desktop Fluidd Replacement (Skeleton)
+
+This directory contains a minimal prototype for a desktop application that can run on a Raspberry Pi and control Klipper/Moonraker printers. It is **not** a full replacement for Fluidd yet but demonstrates how to start a standalone GUI that communicates with the Moonraker API.
+
+## Requirements
+
+- Python 3.9+
+- `requests` library for HTTP communication
+- `tkinter` for the user interface (ships with most Python installations)
+
+You can install dependencies on the Raspberry Pi with:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Running
+
+```bash
+python3 main.py
+```
+
+The script launches a small desktop window and attempts to connect to Moonraker at `http://localhost:7125`. Adjust the URL in `main.py` if your Moonraker instance runs elsewhere.
+
+## Notes
+
+This is just a skeleton to show how a desktop UI might integrate with the Moonraker API. A full application would need additional panels, printer state handling, file management, and much more.

--- a/desktop_app/main.py
+++ b/desktop_app/main.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Minimal desktop interface for Moonraker printers.
+
+This script demonstrates how to build a Tkinter-based GUI that connects
+to the Moonraker API. It is a starting point and not a full-featured
+Fluidd replacement.
+"""
+import tkinter as tk
+from tkinter import messagebox
+import requests
+
+MOONRAKER_URL = "http://localhost:7125"
+
+
+def fetch_printer_info():
+    """Fetch basic printer info from Moonraker."""
+    try:
+        response = requests.get(f"{MOONRAKER_URL}/printer/info")
+        response.raise_for_status()
+        data = response.json()
+        return data.get("result", {})
+    except Exception as exc:
+        messagebox.showerror("Connection Error", str(exc))
+        return None
+
+
+def on_refresh():
+    info = fetch_printer_info()
+    if info:
+        text = "Printer Info:\n" + "\n".join(f"{k}: {v}" for k, v in info.items())
+        info_label.config(text=text)
+    else:
+        info_label.config(text="Failed to fetch printer info")
+
+
+root = tk.Tk()
+root.title("Desktop Fluidd (Prototype)")
+
+refresh_button = tk.Button(root, text="Refresh Printer Info", command=on_refresh)
+refresh_button.pack(pady=10)
+
+info_label = tk.Label(root, text="Click refresh to fetch printer info", justify="left")
+info_label.pack(padx=10, pady=10)
+
+root.mainloop()

--- a/desktop_app/requirements.txt
+++ b/desktop_app/requirements.txt
@@ -1,0 +1,1 @@
+requests


### PR DESCRIPTION
## Summary
- add a `desktop_app` folder with a simple Tkinter prototype
- include a README with instructions and requirements

## Testing
- `python3 -m py_compile desktop_app/main.py`

------
https://chatgpt.com/codex/tasks/task_e_6844ca51bd5c832fb81b93bc921af794